### PR TITLE
Test framework tweaks for `arm64` Macs.

### DIFF
--- a/src/Internal/ModelImpl.cs
+++ b/src/Internal/ModelImpl.cs
@@ -11,6 +11,8 @@ namespace Femyou.Internal
   {
     public ModelImpl(string fmuPath)
     {
+      var res = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture;
+      var res2 = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
       try
       {
         TmpFolder = Path.Combine(Path.GetTempPath(),nameof(Femyou),Path.GetFileName(fmuPath));
@@ -23,7 +25,7 @@ namespace Femyou.Internal
           .Select(sv => new Variable(sv) as IVariable)
           .ToDictionary(sv => sv.Name, sv => sv);
         var fmiVersion = root!.Attribute("fmiVersion")?.Value;
-        ModelVersion = fmiVersion!.StartsWith("2.") ? (IModelVersion) new ModelVersion2() : new ModelVersion3();
+        ModelVersion = fmiVersion!.StartsWith("2.") ? (IModelVersion)new ModelVersion2() : new ModelVersion3();
         var coSimulationId = root
           !.Element(ModelVersion.CoSimulationElementName)
           !.Attribute("modelIdentifier")

--- a/src/Internal/ModelVersion2.cs
+++ b/src/Internal/ModelVersion2.cs
@@ -8,13 +8,16 @@ namespace Femyou.Internal
   {
     public string CoSimulationElementName { get; } = "CoSimulation";
     public string GuidAttributeName { get; } = "guid";
-    public string RelativePath(string name, Architecture architecture, PlatformID platform) =>
-      platform switch
+    public string RelativePath(string name, Architecture architecture, PlatformID platform)
+    {
+      var isDarwin = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Darwin");
+      return platform switch
       {
-        PlatformID.Unix => Path.Combine("binaries", "linux" + MapArchitecture(architecture), name + ".so"),
+        PlatformID.Unix => Path.Combine("binaries", (isDarwin ? "darwin" : "linux") + MapArchitecture(architecture), name + (isDarwin ? ".dylib" : ".so")),
         PlatformID.Win32NT => Path.Combine("binaries", "win" + MapArchitecture(architecture), name + ".dll"),
         _ => throw new FmuException($"Unsupported operating system {platform}"),
       };
+    }
 
     public Library Load(string path) => new Library2(path);
 

--- a/src/Internal/ModelVersion3.cs
+++ b/src/Internal/ModelVersion3.cs
@@ -9,14 +9,19 @@ namespace Femyou.Internal
     public string CoSimulationElementName { get; } = "BasicCoSimulation";
     public string GuidAttributeName { get; } = "instantiationToken";
     public Library Load(string path) => new Library3(path);
-    
-    public string RelativePath(string name, Architecture architecture, PlatformID platform) =>
-      platform switch
+
+    public string RelativePath(string name, Architecture architecture, PlatformID platform)
+    {
+      var isDarwin = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Darwin");
+      return platform switch
       {
-        PlatformID.Unix => Path.Combine("binaries", MapArchitecture(architecture)+"-linux", name + ".so"),
-        PlatformID.Win32NT => Path.Combine("binaries", MapArchitecture(architecture)+"-windows", name + ".dll"),
+        // [VS] MacOS identifies as `Arm64`, but doesn't use `aarch64`.
+        // Derived from looking at what the reference FMUs build.
+        PlatformID.Unix => Path.Combine("binaries", isDarwin ? (architecture == Architecture.Arm64 ? "darwin64" : "x86_64-darwin") : MapArchitecture(architecture) + "-linux", name + (isDarwin ? ".dylib" : ".so")),
+        PlatformID.Win32NT => Path.Combine("binaries", MapArchitecture(architecture) + "-windows", name + ".dll"),
         _ => throw new FmuException($"Unsupported operating system {platform}"),
       };
+    }
 
     private string MapArchitecture(Architecture architecture) =>
       architecture switch

--- a/tests/CallbacksTests.cs
+++ b/tests/CallbacksTests.cs
@@ -11,6 +11,9 @@ public class CallbacksTests
   public CallbacksTests(int version)
   {
     _getFmuPath = name => TestTools.GetFmuPath(version, name);
+    var isDarwin = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Darwin");
+    var isArm64 = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
+    Assume.That(version == 3 && isDarwin && isArm64, Is.False);
   }
   private Func<string, string> _getFmuPath;
 

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -12,6 +12,10 @@ public class InstanceTests
   public InstanceTests(int version)
   {
     _getFmuPath = name => TestTools.GetFmuPath(version, name);
+    var isDarwin = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Darwin");
+    var isArm64 = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
+    Assume.That(version == 3 && isDarwin && isArm64, Is.False);
+
   }
   private Func<string, string> _getFmuPath;
 

--- a/tests/ModelTests.cs
+++ b/tests/ModelTests.cs
@@ -11,6 +11,9 @@ namespace Femyou.Tests
     public ModelTests(int version)
     {
       _getFmuPath = name => TestTools.GetFmuPath(version, name);
+      var isDarwin = System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Darwin");
+      var isArm64 = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
+      Assume.That(version == 3 && isDarwin && isArm64, Is.False);
     }
     private readonly Func<string, string> _getFmuPath;
     


### PR DESCRIPTION
Add MacOS support for an up-to-date M1 with 15.7, which identifies as `arm64`.
Note that this is still wrt. to the older version of the reference FMUs via the git submodule. Their build-script doesn't build `arm64` for FMI-version 3, hence I chose to set those tests to *ignore* explicitly.

TODO: There's still a loose end in the platform tests where expected paths are computed.
TODO: check against an older Intel Mac at work.

For the latest current reference FMUs (v0.0.39), there are two Mac-related pull-requests, the `arm64`-one being https://github.com/modelica/Reference-FMUs/pull/660. Once a solution to this materialises in the reference-FMUs, the path-computation needs a revisit.

