### PR TITLE
Chase FMI 3

### DIFF
--- a/src/Internal/Library3.cs
+++ b/src/Internal/Library3.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using Femyou.Interop;
 
 namespace Femyou.Internal
@@ -62,7 +60,7 @@ namespace Femyou.Internal
         FMI3.fmi3Boolean.fmi3False,
         IntPtr.Zero,
         0,
-        IntPtr.Zero, //callbacks.Custom,
+        callbacks.Custom,
         ((Callbacks3)callbacks).LogMessageDelegate,
         IntPtr.Zero
       );

--- a/src/Internal/ModelVersion3.cs
+++ b/src/Internal/ModelVersion3.cs
@@ -6,7 +6,7 @@ namespace Femyou.Internal
 {
   public class ModelVersion3 : IModelVersion
   {
-    public string CoSimulationElementName { get; } = "BasicCoSimulation";
+    public string CoSimulationElementName { get; } = "CoSimulation";
     public string GuidAttributeName { get; } = "instantiationToken";
     public Library Load(string path) => new Library3(path);
     

--- a/src/Interop/fmi3FunctionTypes.cs
+++ b/src/Interop/fmi3FunctionTypes.cs
@@ -28,15 +28,16 @@ namespace Femyou.Interop
       fmi3String category,
       fmi3String message);
 
-    public delegate fmi3Instance fmi3InstantiateBasicCoSimulationTYPE(
+    public delegate fmi3Instance fmi3InstantiateCoSimulationTYPE(
       fmi3String instanceName,
       fmi3String instantiationToken,
       fmi3String resourceLocation,
       fmi3Boolean visible,
       fmi3Boolean loggingOn,
-      fmi3Boolean intermediateVariableGetRequired,
-      fmi3Boolean intermediateInternalVariableGetRequired,
-      fmi3Boolean intermediateVariableSetRequired,
+      fmi3Boolean eventModeUsed,
+      fmi3Boolean earlyReturnAllowed,
+      IntPtr requiredIntermediateVariables, /* FAKE, pointer */
+      fmi3Integer nRequiredIntermediateVariables, /* FAKE, size_t */
       fmi3InstanceEnvironment instanceEnvironment,
       fmi3CallbackLogMessage logMessage,
       IntPtr intermediateUpdate);
@@ -64,7 +65,8 @@ namespace Femyou.Interop
       fmi3Float64 currentCommunicationPoint,
       fmi3Float64 communicationStepSize,
       fmi3Boolean noSetFMUStatePriorToCurrentPoint,
-      IntPtr terminate,
+      IntPtr eventHandlingNeeded,
+      IntPtr terminateSimulation,
       IntPtr earlyReturn,
       IntPtr lastSuccessfulTime);
 

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -40,11 +40,11 @@ public class InstanceTests
 
   static readonly (string, string, Func<IInstance, IEnumerable<IVariable>, IEnumerable<object>>, object, Action<IInstance, IEnumerable<IVariable>>, object)[] DefaultValuesTestCases =
   {
-    ("Feedthrough.fmu", "bool_in", (i,v) => i.ReadBoolean(v).Cast<object>(), false, (i,vs) => i.WriteBoolean(vs.Select(v => (v,true))), true),
-    ("Feedthrough.fmu", "string_param", (i,v) => i.ReadString(v), "Set me!", (i,vs) => i.WriteString(vs.Select(v => (v,"Foo"))), "Foo"),
+    ("Feedthrough.fmu", "Boolean_input", (i,v) => i.ReadBoolean(v).Cast<object>(), false, (i,vs) => i.WriteBoolean(vs.Select(v => (v,true))), true),
+    ("Feedthrough.fmu", "String_input", (i,v) => i.ReadString(v), "Set me!", (i,vs) => i.WriteString(vs.Select(v => (v,"Foo"))), "Foo"),
     ("BouncingBall.fmu", "g", (i,v) => i.ReadReal(v).Cast<object>(), -9.81, (i,vs) => i.WriteReal(vs.Select(v => (v,3.46))), 3.46),
     ("Stair.fmu", "counter", (i,v) => i.ReadInteger(v).Cast<object>(), 1, (i,vs) => {}, 1),
-    ("Feedthrough.fmu", "int_in", (i,v) => i.ReadInteger(v).Cast<object>(), 0, (i,vs) => i.WriteInteger(vs.Select(v => (v,28))), 28)
+    ("Feedthrough.fmu", "Int32_input", (i,v) => i.ReadInteger(v).Cast<object>(), 0, (i,vs) => i.WriteInteger(vs.Select(v => (v,28))), 28)
   };
 
   [Test]
@@ -64,17 +64,17 @@ public class InstanceTests
   {
     using var model = Model.Load(_getFmuPath("Feedthrough.fmu"));
     using var instance = Tools.CreateInstance(model, "reference");
-    instance.WriteReal((model.Variables["real_fixed_param"], 1));
-    instance.WriteString((model.Variables["string_param"], "FMI is awesome!"));
-    var real_tunable_param = model.Variables["real_tunable_param"];
-    var real_continuous_in = model.Variables["real_continuous_in"];
-    var real_continuous_out = model.Variables["real_continuous_out"];
-    var real_discrete_in = model.Variables["real_discrete_in"];
-    var real_discrete_out = model.Variables["real_discrete_out"];
-    var int_in = model.Variables["int_in"];
-    var int_out = model.Variables["int_out"];
-    var bool_in = model.Variables["bool_in"];
-    var bool_out = model.Variables["bool_out"];
+    instance.WriteReal((model.Variables["Float64_fixed_parameter"], 1));
+    instance.WriteString((model.Variables["String_input"], "FMI is awesome!"));
+    var real_tunable_param = model.Variables["Float64_tunable_parameter"];
+    var real_continuous_in = model.Variables["Float64_continuous_input"];
+    var real_continuous_out = model.Variables["Float64_continuous_output"];
+    var real_discrete_in = model.Variables["Float64_discrete_input"];
+    var real_discrete_out = model.Variables["Float64_discrete_output"];
+    var int_in = model.Variables["Int32_input"];
+    var int_out = model.Variables["Int32_output"];
+    var bool_in = model.Variables["Boolean_input"];
+    var bool_out = model.Variables["Boolean_output"];
     instance.StartTime(0.0);
     foreach (var pt in feedthroughScenario)
     {

--- a/tests/ModelTests.cs
+++ b/tests/ModelTests.cs
@@ -14,7 +14,7 @@ namespace Femyou.Tests
     }
     private readonly Func<string, string> _getFmuPath;
     
-    [TestCase("BouncingBall.fmu", "bouncingball", "This model calculates the trajectory, over time, of a ball dropped from a height of 1 m.")]
+    [TestCase("BouncingBall.fmu", "bouncingball", "This model calculates the trajectory, over time, of a ball dropped from a height of 1 m")]
     [TestCase("VanDerPol.fmu", "van der pol oscillator", "This model implements the van der Pol oscillator")]
     public void ModelHasNameAndDescription(string filename, string expectedName, string expectedDescription)
     {
@@ -30,8 +30,8 @@ namespace Femyou.Tests
       var fmuPath = _getFmuPath("Feedthrough.fmu");
       using var model = Model.Load(fmuPath);
       Assert.That(model.Variables.Count(), Is.GreaterThanOrEqualTo(11));
-      Assert.That(model.Variables["string_param"].Description, Is.EqualTo("String parameter"));
-      Assert.That(model.Variables["bool_out"].Description, Is.EqualTo("boolean output"));
+      Assert.That(model.Variables["String_input"].Description, Is.EqualTo("String parameter"));
+      Assert.That(model.Variables["Boolean_output"].Description, Is.EqualTo("boolean output"));
     }
   }
 }

--- a/tests/TestTools.cs
+++ b/tests/TestTools.cs
@@ -9,7 +9,7 @@ namespace Femyou.Tests
     public static string GetFmuPath(int version, string filename) =>
       Path.Combine(FmuFolder(version), filename);
     public static string FmuFolder(int version) =>
-      Path.Combine(BaseFolder, "FMU", $"bin{version}", "dist");
+      Path.Combine(BaseFolder, "FMU", $"bin{version}", "fmus");
     public static string BaseFolder => Tools
       .GetBaseFolder(new Uri(Assembly.GetExecutingAssembly().Location).AbsolutePath, nameof(Femyou));
   }


### PR DESCRIPTION
Both the FMI 3 API and the reference FMUs have evolved.

* chase FMI 3 API: I've only reviewed `Instantiate` and `Step` so far.
* chase reference FMUs: bump, and update some variable names.

Test-suite currently has a few failures: the behaviour of the reference FMUs is slightly different and needs updating, and `CallbacksTests(3)` fails hard without a chance to catch the exception. It might be that invalid `valueReferences` are no longer a good idea.